### PR TITLE
Fix: Ensure page parameter is safely cast to an integer in LogEntries…

### DIFF
--- a/log_inspector/views.py
+++ b/log_inspector/views.py
@@ -54,6 +54,10 @@ class LogEntriesView(TemplateView):
 
         log_entries = get_log_entries(filename)
         log_entries = filter_log_entries(log_entries, search)
+        try:
+            page = int(page)
+        except ValueError:
+            page = 1
 
         max_lines = settings.LOG_INSPECTOR_MAX_READ_LINES if not is_live_action else settings.LOG_INSPECTOR_PAGE_LENGTH
         paginator = Paginator(list(islice(log_entries, max_lines)), settings.LOG_INSPECTOR_PAGE_LENGTH)


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a minor update to the `LogEntriesView` class. The key change ensures the `page` parameter from the request is explicitly cast to an integer, providing safer handling and preventing potential errors from invalid input.

#### Changes:
- Added a safeguard to cast the `page` parameter to an integer using `int()`.
- Improved error handling to default to the first page in case of invalid or missing `page` values.

#### Benefits:
- Enhances the robustness of pagination logic.
- Prevents runtime errors caused by invalid `page` values in requests.

Please review the changes and let me know if any additional adjustments are needed!


@peyzor @shayadev Please check this PR